### PR TITLE
Fix Polaris locale alias for build

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,7 @@
+import { createRequestHandler } from '@remix-run/vercel';
+import * as build from '../build/server/index.js';
+
+export default createRequestHandler({
+  build,
+  mode: process.env.NODE_ENV,
+});

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@remix-run/eslint-config": "^2.16.1",
     "@remix-run/fs-routes": "2.16.7",
     "@remix-run/route-config": "2.16.7",
+    "@remix-run/vercel": "2.16.7",
     "@shopify/api-codegen-preset": "^1.1.1",
     "@types/eslint": "^9.6.1",
     "@types/node": "^22.2.0",
@@ -84,7 +85,8 @@
     "@remix-run/node": "2.16.7",
     "@remix-run/serve": "2.16.7",
     "@remix-run/fs-routes": "2.16.7",
-    "@remix-run/route-config": "2.16.7"
+    "@remix-run/route-config": "2.16.7",
+    "@remix-run/vercel": "2.16.7"
   },
   "author": "Carlos R"
 }

--- a/remix.config.ts
+++ b/remix.config.ts
@@ -1,0 +1,14 @@
+import type { AppConfig } from "@remix-run/dev";
+
+export default {
+  ignoredRouteFiles: ["**/.*"],
+  serverBuildPath: "build/server/index.js",
+  assetsBuildDirectory: "public/build",
+  future: {
+    v3_fetcherPersist: true,
+    v3_relativeSplatPath: true,
+    v3_throwAbortReason: true,
+    v3_lazyRouteDiscovery: true,
+    v3_singleFetch: false
+  }
+} satisfies AppConfig;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "version": 3,
+  "buildCommand": "npm run build",
+  "routes": [
+    {
+      "src": "^/build/(.*)$",
+      "headers": { "cache-control": "public, max-age=31536000, immutable" },
+      "dest": "/build/$1"
+    },
+    { "src": "/(.*)", "dest": "/api/index.js" }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
   // Alias que evita el import con "with { type: 'json' }" de Polaris
   resolve: {
     alias: {
-      "@shopify/polaris/locales/en.json":       "@shopify/polaris/locales/en.json": "./app/aliases/polaris-en.js",,
+      "@shopify/polaris/locales/en.json": "./app/aliases/polaris-en.js",
     },
   },
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,15 +4,22 @@ import { defineConfig, type Plugin } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { vitePlugin as remix } from "@remix-run/dev";
 import { installGlobals } from "@remix-run/node";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 installGlobals({ nativeFetch: true });
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 function importAttributesCompat(): Plugin {
   return {
     name: "import-attributes-compat",
     enforce: "pre",
-    transform(code, id) {
+    load(id) {
       if (!id.includes("node_modules")) return null;
+      const code = fs.readFileSync(id, "utf8");
       const patched = code.replace(
         /from\s+([\'\"][^\'\"]+\.json[\'\"])\s+with\s*{\s*type\s*:\s*['"]json['"]\s*\}/g,
         "from $1 assert { type: 'json' }",
@@ -39,10 +46,16 @@ export default defineConfig({
     }),
   ],
 
-  // Alias que evita el import con "with { type: 'json' }" de Polaris
+  // Alias para locales de Polaris y módulos nativos de Node
   resolve: {
     alias: {
-      "@shopify/polaris/locales/en.json": "./app/aliases/polaris-en.js",
+      "@shopify/polaris/locales/en.json": path.resolve(
+        __dirname,
+        "app/aliases/polaris-en.js",
+      ),
+      crypto: "node:crypto",
+      path: "node:path",
+      fs: "node:fs",
     },
   },
 
@@ -51,6 +64,7 @@ export default defineConfig({
     exclude: [
       "@shopify/shopify-app-remix",
       "@shopify/polaris/locales/en.json",
+      "@vercel/remix",
     ],
   },
 


### PR DESCRIPTION
## Summary
- fix Vite alias for Polaris locale to avoid unsupported `with` JSON import

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*

------
https://chatgpt.com/codex/tasks/task_e_68c0986f10208324adfe2c78b3459a09